### PR TITLE
flake.nix: clean up, readme: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# nix-zulip
+
+We're packaging [zulip](https://github.com/zulip/zulip/) for NixOS. The repository includes a package + deps, a NixOS module and an integration test.
+
+## Development
+
+```console
+# build the package
+nix build
+
+# run an interactive VM
+nix run
+
+# Build the test
+nix build .#checks.<triplet>.default
+```

--- a/flake.nix
+++ b/flake.nix
@@ -1,48 +1,72 @@
 {
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
-  outputs = inputs:
+  outputs =
+    { self, nixpkgs }:
     let
-      inherit (inputs.nixpkgs) lib;
-      foreach = xs: f: with lib; foldr recursiveUpdate { } (
-        if isList xs then map f xs
-        else if isAttrs xs then mapAttrsToList f xs
-        else throw "foreach: expected list or attrset but got ${typeOf xs}"
-      );
-      overlay = final: prev: {
-        zulip = final.callPackage ./package.nix { };
-      };
-      nixosConfig = { modulesPath, ... }: {
-        imports = [
-          "${modulesPath}/virtualisation/qemu-vm.nix"
-          ./module.nix
-        ];
-        virtualisation.graphics = false;
-        users.extraUsers.root.password = "root";
-        services.getty.autologinUser = "root";
-        services.zulip = {
-          enable = true;
-          settings = {
-            EXTERNAL_HOST = "example.com";
-            ZULIP_ADMINISTRATOR = "admin@example.com";
-            ZULIP_SERVICE_PUSH_NOTIFICATIONS = true;
-          };
-        };
-      };
+      inherit (nixpkgs) lib;
+      systems = builtins.attrNames nixpkgs.legacyPackages;
+      forAllSystems = f: lib.genAttrs systems (system: f system nixpkgs.legacyPackages.${system});
     in
     {
-      inherit overlay;
-    }
-    //
-    foreach inputs.nixpkgs.legacyPackages (system: pkgs':
-      let pkgs = pkgs'.extend overlay; in
-      {
-        legacyPackages.${system} = pkgs;
-        packages.${system} = rec {
-          inherit (pkgs.nixos nixosConfig) vm;
-          default = vm;
+      packages = forAllSystems (
+        system: pkgs: {
+          default = self.packages.${system}.zulip-server;
+          zulip-server = pkgs.callPackage ./package.nix { };
+          vm = self.nixosConfigurations.vm.config.system.build.toplevel;
+        }
+      );
+
+      overlays.default = final: prev: {
+        inherit (self.packages.${final.system}) zulip-server;
+      };
+
+      nixosModules.default = ./module.nix;
+
+      nixosConfigurations.vm = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        pkgs = import nixpkgs {
+          system = "x86_64-linux";
+          overlays = [
+            self.overlays.default
+          ];
         };
-        checks.${system}.default = pkgs.nixosTest (import ./test.nix);
-      }
-    );
+
+        modules = [
+          "${nixpkgs}/nixos/modules/virtualisation/qemu-vm.nix"
+          self.nixosModules.default
+          (
+            { modulesPath, ... }:
+            {
+              virtualisation.graphics = false;
+              users.extraUsers.root.password = "root";
+              services.getty.autologinUser = "root";
+              services.zulip = {
+                enable = true;
+                settings = {
+                  EXTERNAL_HOST = "example.com";
+                  ZULIP_ADMINISTRATOR = "admin@example.com";
+                  ZULIP_SERVICE_PUSH_NOTIFICATIONS = true;
+                };
+              };
+            }
+          )
+        ];
+      };
+
+      apps = forAllSystems (
+        system: pkgs: {
+          default = {
+            type = "app";
+            program = "${self.nixosConfigurations.vm.config.system.build.vm}/bin/run-nixos-vm";
+          };
+        }
+      );
+
+      checks = forAllSystems (
+        system: pkgs: {
+          default = (pkgs.extend self.overlays.default).nixosTest (import ./test.nix);
+        }
+      );
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,9 @@
             { modulesPath, ... }:
             {
               virtualisation.graphics = false;
+              virtualisation.qemu.options = [
+                "-netdev user,id=n0,hostfwd=tcp::8080-:443"
+              ];
               users.extraUsers.root.password = "root";
               services.getty.autologinUser = "root";
               services.zulip = {

--- a/module.nix
+++ b/module.nix
@@ -30,7 +30,7 @@ in
 {
   options.services.zulip = {
     enable = lib.mkEnableOption "zulip";
-    package = lib.mkPackageOption pkgs "zulip" { };
+    package = lib.mkPackageOption pkgs "zulip-server" { };
     createPostgresqlDatabase = lib.mkOption {
       type = lib.types.bool;
       default = true;


### PR DESCRIPTION
This cleans up the flake a bit, and adds a few more outputs:

- The vm config as a nixosConfiguration output
- The nixos module
- The zulip-server package (this is now also the default package)
- The vm as a runnable app via `nix run`