### PR TITLE
nixos/zulip: use bindmounts to install settings file

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -354,9 +354,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'openssl' '${lib.getExe openssl}' \
       --replace-fail "if [ \"\$EUID\" -ne 0 ]; then" "if false; then"
 
-    substituteInPlace zproject/configured_settings.py \
-      --replace-fail "from .prod_settings import *" "import sys; sys.path.append(\"/var/lib/zulip\"); from prod_settings import *"
-
     substituteInPlace zproject/computed_settings.py \
       --replace-fail "/var" "$out/env/var" \
       --replace-fail "/home" "$out/env/home"
@@ -388,6 +385,8 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/env/etc/ssl/private
     mkdir -p $out/env/etc/ssl/certs
     mkdir -p $out/env/etc/zulip
+
+    mkdir -p "$out"/zulip/zproject/prod_settings
 
     #mkdir -p prod-static/serve
     #cp -rT prod-static/serve $out/env/home/zulip/prod-static


### PR DESCRIPTION
This PR replaces the `sys.path` patching with systemd bindmounts. It *should* be a bit less brittle on potentially breaking software updates, and it also makes whatever imports are needed inside the settings file easier (the earlier import statement was broken).

In addition, I've moved the `zulip.conf` to a bindmount as well. We should declare an option for this (as well as `zulip-secrets.conf`), but maybe in a later PR.

I also removed the "do we use this" `TODO`. I think we'll be using `LogDirectory` later on (see mentions of `/var/log/zulip` here: https://github.com/zulip/zulip/blob/main/zproject/computed_settings.py#L755-L778). Not sure about `StateDirectory`, but it's marked as the working dir, so let's keep it for now.