### PR TITLE
nixos/zulip: use `preStart`, generate secrets, remove unused stuff

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -69,7 +69,7 @@ in
       after = [ "network.target" ] ++ lib.optional cfg.createPostgresqlDatabase "postgresql.service";
       wantedBy = [ "multi-user.target" ];
 
-      script = ''
+      preStart = ''
         cp -r "${cfg.package}/env" .
         chmod -R +w .
 
@@ -94,6 +94,8 @@ in
         RestartSec = 3;
         DynamicUser = true;
         WorkingDirectory = "/var/lib/zulip";
+
+        ExecStart = "${pkgs.coreutils}/bin/echo TODO: start the program";
 
         StateDirectory = [ "zulip" ];
         RuntimeDirectory = [ "zulip/zulip-server" ];

--- a/module.nix
+++ b/module.nix
@@ -91,7 +91,7 @@ in
         fi
 
         # TODO do this conditionally if the cache does not yet exist
-        python /run/zulip/zulip-server/tools/update-prod-static
+        /run/zulip/zulip-server/tools/update-prod-static
 
         # TODO should this only run if e.g. ./env does not exist? or maybe we can make a file called .initialised or something 
         PYTHONUNBUFFERED=1 /run/zulip/zulip-server/manage.py register_server

--- a/module.nix
+++ b/module.nix
@@ -70,9 +70,6 @@ in
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        cp -r "${cfg.package}/env" .
-        chmod -R +w .
-
         # Not for production
         /run/zulip/zulip-server/scripts/setup/generate-self-signed-cert \
           --exists-ok "''${EXTERNAL_HOST:-$(hostname)}"

--- a/module.nix
+++ b/module.nix
@@ -70,10 +70,6 @@ in
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        # Not for production
-        /run/zulip/zulip-server/scripts/setup/generate-self-signed-cert \
-          --exists-ok "''${EXTERNAL_HOST:-$(hostname)}"
-
         # TODO do this conditionally, if secrets do not yet exist
         /run/zulip/zulip-server/scripts/setup/generate_secrets.py --production
 

--- a/package.nix
+++ b/package.nix
@@ -395,8 +395,6 @@ stdenv.mkDerivation (finalAttrs: {
     pushd "$out"/bin
     ln -s ../zulip/manage.py zulip-manage
     ln -s ../zulip/tools/update-prod-static zulip-update-prod-static
-    ln -s ../zulip/scripts/setup/generate-self-signed-cert zulip-generate-self-signed-cert
-    ln -s ../zulip/scripts/setup/generate_secrets.py zulip-generate-secrets
     popd
 
     runHook postInstall

--- a/package.nix
+++ b/package.nix
@@ -354,9 +354,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'openssl' '${lib.getExe openssl}' \
       --replace-fail "if [ \"\$EUID\" -ne 0 ]; then" "if false; then"
 
-    substituteInPlace zproject/configured_settings.py \
-      --replace-fail "from .prod_settings import *" "import sys; sys.path.append(\"/var/lib/zulip\"); from prod_settings import *"
-
     substituteInPlace zproject/computed_settings.py \
       --replace-fail "/var" "$out/env/var" \
       --replace-fail "/home" "$out/env/home"
@@ -388,6 +385,8 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/env/etc/ssl/private
     mkdir -p $out/env/etc/ssl/certs
     mkdir -p $out/env/etc/zulip
+
+    mkdir -p "$out"/zulip/zproject/prod_settings
 
     #mkdir -p prod-static/serve
     #cp -rT prod-static/serve $out/env/home/zulip/prod-static

--- a/package.nix
+++ b/package.nix
@@ -382,10 +382,6 @@ stdenv.mkDerivation (finalAttrs: {
     chmod -R +w "$out"/zulip
     cp -r node_modules "$out"/zulip
 
-    mkdir -p $out/env/etc/ssl/private
-    mkdir -p $out/env/etc/ssl/certs
-    mkdir -p $out/env/etc/zulip
-
     mkdir -p "$out"/zulip/zproject/prod_settings
 
     #mkdir -p prod-static/serve


### PR DESCRIPTION
This PR is built on top of #12, it should probably be reviewed and merged first, marking as draft in the meanwhile.

---

This PR does a few things:

#### Moves setup logic to the `preStart` script of the unit, leaving `ExecStart` as a TODO for now.

`preStart` is still failing, so let's leave it for later (currently dies at `update-prod-static`, with some error about the config)

#### Removes the "copy `env` from package" step.

We won't be needing the SSL dirs, nor the `zulip` dir.

#### Removes the self signed cert generation step.

At some point we are going to need a reverse proxy as a request router for a split backend, so it's better if the user specifies their own certs or use acme integration, and we use snakeoil certs for the nixos test.

#### Removes the [secret generation script](https://github.com/zulip/zulip/blob/main/scripts/setup/generate_secrets.py) in favour of an inline bash step.

The script wants to write secrets to redis' etc, and tries to determine what you need based on your settings, which in turn makes it harder to determine if we need to regenerate the file. Instead of doing a bunch of patching and conditionals and whatnot, this seems like an easier solution.

The secret generation step looks a bit weird with the `printf` and `install`, but the intention is to avoid exposing the secrets in `/proc/<pid>/cmdline` or in the secrets file with wrong permissions for a brief second. `printf` is a bash builtin, so it should show up in `/proc` AFAIK.