### PR TITLE
package.nix: remove getopt from `buildInputs`

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -326,7 +326,6 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     jq
     crudini
-    getopt
 
     #build-essential
     libffi # libffi-devel


### PR DESCRIPTION
Fixup for #11, which switched to using `getopt` from `util-linux` and patching it into the script via `substituteInPlace`. Package currently doesn't eval