### PR TITLE
WIP: build emoji cache during buildtime

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,16 @@
         system: pkgs: {
           default = inputs.self.packages.${system}.zulip-server;
           zulip-server = pkgs.callPackage ./package.nix { };
+
+          # TODO: would it be easier if this was just included in the zulip-server derivation?
+          #       How much data is it, would it be unfair to put it in the binary cache?
+          zulip-emoji-cache = pkgs.callPackage ({ runCommand, zulip-server, vips }: runCommand "zulip-emoji-cache" {
+            env.ZULIP_EMOJI_CACHE_BASE_PATH = "${placeholder "out"}";
+            nativeBuildInputs = [ vips ];
+          } ''
+            "${zulip-server}"/zulip/tools/setup/emoji/build_emoji
+          '') { inherit (inputs.self.packages.${system}) zulip-server; };
+
           vm = inputs.self.nixosConfigurations.vm.config.system.build.toplevel;
         }
       );

--- a/package.nix
+++ b/package.nix
@@ -370,7 +370,9 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "/home" "$out/env/home"
 
     substituteInPlace tools/setup/emoji/build_emoji \
-      --replace "/srv" "$out/env/srv"
+      --replace 'EMOJI_CACHE_BASE_PATH = "/srv/zulip-emoji-cache"' "EMOJI_CACHE_BASE_PATH = os.environ['ZULIP_EMOJI_CACHE_BASE_PATH']" \
+      --replace 'shutil.copyfile(input_img_file, output_img_file)' "" \
+      --replace 'TARGET_STATIC_EMOJI' "os.exit(0); TARGET_STATIC_EMOJI"
 
     substituteInPlace zerver/lib/compatibility.py \
       --replace "LAST_SERVER_UPGRADE_TIME = datetime.strptime" "LAST_SERVER_UPGRADE_TIME = timezone_now() or datetime.strptime"


### PR DESCRIPTION
`update-prod-static` runs a script named `build-emoji`, which uses some sprites and renders a bunch of combinations of them, as well as converting the resulting images to different formats. It expects to be able to do this, and then overwrite symlinks and dirs back in the project directory. This is reasonable on a normal deployment, but impossible on NixOS due to the readonly nix store.

Instead, we can build the emoji cache as a separate derivation, and then either bindmount it back over the directory(ies) in question, or create a request route in the reverse proxy in the future sometime.