### PR TITLE
WIP: build static content in a separate derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
         system: pkgs: {
           default = inputs.self.packages.${system}.zulip-server;
           zulip-server = pkgs.callPackage ./package.nix { };
+          zulip-static-content = inputs.self.packages.${system}.zulip-server.passthru.static-content;
           vm = inputs.self.nixosConfigurations.vm.config.system.build.toplevel;
         }
       );

--- a/package.nix
+++ b/package.nix
@@ -455,16 +455,12 @@ let
       writeShellScript,
       webpack-cli,
 
-      # nodejs,
+      # TODO: remove
       strace,
     }:
     runCommandLocal "zulip-static-content"
       {
-        nativeBuildInputs = [
-          vips
-          # nodejs
-          # zulip-server.pnpmDeps.nativeBuildInputs.pnpm
-        ];
+        nativeBuildInputs = [ vips ];
 
         env = {
           DISABLE_MANDATORY_SECRET_CHECK = "True";
@@ -487,22 +483,17 @@ let
               stats = "errors-only";
             }}
           '';
-
-          # BABEL_DISABLE_CACHE = "1";
-          # BROWSERSLIST_IGNORE_OLD_DATA = "1";
         };
       }
       ''
-        # TODO: can we get away with removing this cp once this builds?
-        # cp -r '${zulip-server}'/zulip .
+        # TODO: does `web,static,node_modules` need to be stored in `$out` or can we create a webpack
+        #       bundle in a tmpdir and then move it to `$out`?
         mkdir -p "$out"
         cp -r '${zulip-server}'/zulip/{web,static,node_modules} "$out/"
         chmod -R +w "$out/"
 
-        # ${lib.getExe strace} -f -e trace=file zulip/tools/update-prod-static
+        # ${lib.getExe strace} -f -e trace=file '${zulip-server}'/zulip/tools/update-prod-static
         '${zulip-server}'/zulip/tools/update-prod-static
-        # (cd "$out"/web && webpack build --disable-interpret --mode=production --env=ZULIP_VERSION=${zulip-server.version})
-        # ls -lah
       ''
   ) { inherit zulip-server; };
 in

--- a/package.nix
+++ b/package.nix
@@ -359,8 +359,9 @@ let
         --replace-fail "from .prod_settings import *" "import sys; sys.path.append(\"/var/lib/zulip\"); from prod_settings import *"
 
       substituteInPlace zproject/computed_settings.py \
-        --replace-fail "/var" "$out/env/var" \
-        --replace-fail "/home" "$out/env/home"
+        --replace-fail /srv /run/zulip \
+        --replace-fail 'zulip_path("/var/log/zulip' '(f"{os.environ.get("ZULIP_LOG_DIR", "/var/log/zulip")}' \
+        --replace-fail 'zulip_path("/home/zulip' '(f"{os.environ.get("ZULIP_STATE_DIR", "/var/lib/zulip")}'
 
       substituteInPlace scripts/lib/zulip_tools.py \
         --replace "args = [\"sudo\", *sudo_args, \"--\", *args]" "pass" \
@@ -469,6 +470,9 @@ let
           ZULIP_WEB_GENERATED = "${placeholder "out"}/web/generated";
           ZULIP_STATIC_GENERATED = "${placeholder "out"}/static/generated";
           ZULIP_GENERATED_IMAGES_DIR = "${placeholder "out"}/static/images/landing-page/hello/generated";
+
+          ZULIP_LOG_DIR = "/tmp";
+          ZULIP_STATE_DIR = "/tmp";
 
           ZULIP_TOOLS_WEBPACK_REPLACEMENT_SCRIPT = writeShellScript "zulip-tools-webpack-replacement-script" ''
             export BABEL_DISABLE_CACHE=1

--- a/package.nix
+++ b/package.nix
@@ -449,28 +449,35 @@ let
       runCommandLocal,
       zulip-server,
       vips,
+      nodejs,
       strace,
     }:
     runCommandLocal "zulip-static-content"
       {
-        nativeBuildInputs = [ vips ];
+        nativeBuildInputs = [
+          vips
+          nodejs
+          # zulip-server.pnpmDeps.nativeBuildInputs.pnpm
+        ];
 
         env = {
           DISABLE_MANDATORY_SECRET_CHECK = "True";
 
-          ZULIP_EMOJI_CACHE_BASE_PATH = "${placeholder "out"}/cache/emoji";
+          ZULIP_EMOJI_CACHE_BASE_PATH = "${placeholder "out"}/srv/zulip-emoji-cache";
           ZULIP_STATIC_GENERATED = "${placeholder "out"}/static/generated";
           ZULIP_PYGMENTS_DATA = "${placeholder "out"}/web/generated/pygments_data.json";
           ZULIP_TIMEZONE_VALUES = "${placeholder "out"}/web/generated/timezones.json";
           ZULIP_GENERATED_IMAGES_DIR = "${placeholder "out"}/static/images/landing-page/hello/generated";
+
+          BABEL_DISABLE_CACHE = "1";
         };
       }
       ''
         # TODO: can we get away with removing this cp once this builds?
-        cp -r '${zulip-server}'/zulip .
-
-        mkdir -p "$(dirname "$ZULIP_PYGMENTS_DATA")"
-        mkdir -p "$ZULIP_GENERATED_IMAGES_DIR"
+        # cp -r '${zulip-server}'/zulip .
+        mkdir -p "$out"
+        cp -r '${zulip-server}'/zulip/{web,static} "$out/"
+        chmod -R +w "$out/"
 
         # ${lib.getExe strace} -f -e trace=file zulip/tools/update-prod-static
         '${zulip-server}'/zulip/tools/update-prod-static


### PR DESCRIPTION
Succeeds #15

`update-prod-static` builds a bunch of static files. On normal systems, it would run on every update of the program, and update anything that updated with it. With nix, it makes more sense to just generate these in a derivation, automatically updating the content by its dependency on the `zulip-server` derivation.

The scripts are full of logic that wants to edit the zulip source code to include these directories, so there will be a bit of patching needed. We can bindmount this derivation over `/run/zulip/zulip-server` instead, once #12 is good to go.

The processing power needed seems quite lightweight, while the output seems to take a lot of disk space (although I still haven't successfully built it). I'm not yet sure whether we should put this in the binary cache, or just have every user of the module generate this derivation locally on the fly.